### PR TITLE
Fix changes to upstream factoryboy

### DIFF
--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -1,6 +1,5 @@
 import factory
 from django.utils.text import slugify
-from factory.utils import extract_dict
 
 try:
     from wagtail.wagtailcore.models import Collection, Page, Site


### PR DESCRIPTION
Factoryboy has removed `extract_dict` but it wasn't being used anyway